### PR TITLE
Add utility node for waiting within workflow

### DIFF
--- a/admyral/actions/__init__.py
+++ b/admyral/actions/__init__.py
@@ -1,6 +1,10 @@
 from admyral.actions.ai_action import ai_action
 from admyral.actions.send_email import send_email
-from admyral.actions.utilities import deserialize_json_string, serialize_json_string
+from admyral.actions.utilities import (
+    deserialize_json_string,
+    serialize_json_string,
+    wait,
+)
 from admyral.actions.integrations.communication import (
     send_slack_message,
     lookup_slack_user_by_email,
@@ -63,6 +67,7 @@ __all__ = [
     "send_email",
     "deserialize_json_string",
     "serialize_json_string",
+    "wait",
     "send_slack_message",
     "lookup_slack_user_by_email",
     "send_slack_message_to_user_by_email",

--- a/admyral/actions/utilities.py
+++ b/admyral/actions/utilities.py
@@ -46,7 +46,7 @@ def serialize_json_string(
 )
 def wait(
     seconds: Annotated[
-        float,
+        int,
         ArgumentMetadata(
             display_name="Seconds",
             description="Number of seconds to wait.",

--- a/admyral/actions/utilities.py
+++ b/admyral/actions/utilities.py
@@ -1,5 +1,6 @@
 from typing import Annotated
 import json
+import time
 
 from admyral.action import action, ArgumentMetadata
 from admyral.typings import JsonValue
@@ -53,6 +54,4 @@ def wait(
         ),
     ],
 ) -> None:
-    import time
-
     time.sleep(seconds)

--- a/admyral/actions/utilities.py
+++ b/admyral/actions/utilities.py
@@ -37,3 +37,22 @@ def serialize_json_string(
     ],
 ) -> str:
     return json.dumps(json_value)
+
+
+@action(
+    display_name="Wait",
+    display_namespace="Admyral",
+    description="Waits for a specified number of seconds.",
+)
+def wait(
+    seconds: Annotated[
+        float,
+        ArgumentMetadata(
+            display_name="Seconds",
+            description="Number of seconds to wait.",
+        ),
+    ],
+) -> None:
+    import time
+
+    time.sleep(seconds)

--- a/admyral/workers/action_executor.py
+++ b/admyral/workers/action_executor.py
@@ -42,6 +42,7 @@ def action_executor(action_type: str, func: "F") -> "F":
 
                 # make available to the function as a contextvar
                 ctx.set(exec_ctx)
+                # for wait actions, we skip the function call because the waiting is already executed in the WorkflowExecutor
                 if exec_ctx.action_type != "wait":
                     result = await func(**args)
                 else:
@@ -81,7 +82,7 @@ def action_executor(action_type: str, func: "F") -> "F":
                 # make available to the function as a contextvar
                 ctx.set(exec_ctx)
 
-                # check for wait node => don't call the function
+                # for wait actions, we skip the function call because the waiting is already executed in the WorkflowExecutor
                 if exec_ctx.action_type != "wait":
                     result = func(**args)
                 else:

--- a/admyral/workers/action_executor.py
+++ b/admyral/workers/action_executor.py
@@ -42,8 +42,10 @@ def action_executor(action_type: str, func: "F") -> "F":
 
                 # make available to the function as a contextvar
                 ctx.set(exec_ctx)
-
-                result = await func(**args)
+                if exec_ctx.action_type != "wait":
+                    result = await func(**args)
+                else:
+                    result = None
                 throw_if_not_allowed_return_type(result)
             except Exception as e:
                 # Store error
@@ -79,7 +81,11 @@ def action_executor(action_type: str, func: "F") -> "F":
                 # make available to the function as a contextvar
                 ctx.set(exec_ctx)
 
-                result = func(**args)
+                # check for wait node => don't call the function
+                if exec_ctx.action_type != "wait":
+                    result = func(**args)
+                else:
+                    result = None
                 throw_if_not_allowed_return_type(result)
             except Exception as e:
                 # Store error

--- a/admyral/workers/workflow_executor.py
+++ b/admyral/workers/workflow_executor.py
@@ -135,6 +135,9 @@ class WorkflowExecutor:
                     candidates = node.true_children + node.false_children
                 elif isinstance(node, ActionNode):
                     if node.id != "start":
+                        if node.type == "wait":
+                            await asyncio.sleep(node.args.get("seconds", 0))
+
                         step_id, execution_result = await self._execute_action_node(
                             node, execution_state, ctx_dict
                         )

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -1,8 +1,10 @@
 from typing import Annotated
+import time
 
 from admyral.action import action, ArgumentMetadata
 from admyral.workflow import workflow
 from admyral.typings import JsonValue
+from admyral.actions import wait
 
 
 @action(
@@ -78,6 +80,14 @@ def test_example_workflow_execution():
     result = 0
     example_workflow({"x": 2})
     assert result == 0
+
+
+def test_wait_action():
+    start = time.time()
+    wait(seconds=10)
+    end = time.time()
+
+    assert end - start >= 10
 
 
 # @action

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -82,9 +82,14 @@ def test_example_workflow_execution():
     assert result == 0
 
 
-def test_wait_action():
-    start = time.time()
+@workflow
+def wait_workflow(payload: dict[str, JsonValue]):
     wait(seconds=10)
+
+
+def test_wait_workflow_execution():
+    start = time.time()
+    wait_workflow({})
     end = time.time()
 
     assert end - start >= 10


### PR DESCRIPTION
This PR adds a new utility node allowing to suspend the workflow execution for a specified number of seconds.

Related to linear Issue ADM-298