### PR TITLE
Update toast error when workflow name contains space

### DIFF
--- a/web/src/components/save-workflow-button/save-workflow-button.tsx
+++ b/web/src/components/save-workflow-button/save-workflow-button.tsx
@@ -50,7 +50,7 @@ export default function SaveWorkflowButton() {
 			return;
 		}
 		if (workflow.workflowName.includes(SPACE)) {
-			errorToast("Workflow name must contain empty spaces.");
+			errorToast("Workflow name must not contain empty spaces.");
 			return;
 		}
 		saveWorkflow.mutate(workflow);


### PR DESCRIPTION
## What does this PR do?

Just a quick update for the error toast when trying to save a workflow with an empty whitespace.

![image](https://github.com/user-attachments/assets/a0df1ece-564d-4233-a419-dd354d64c81d)
-->

## Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

-   [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.
