### PR TITLE
Update azure_openai.py

### DIFF
--- a/admyral/actions/integrations/ai/azure_openai.py
+++ b/admyral/actions/integrations/ai/azure_openai.py
@@ -14,13 +14,6 @@ from admyral.context import ctx
     secrets_placeholders=["AZURE_OPENAI_SECRET"],
 )
 def azure_openai_chat_completion(
-    model: Annotated[
-        str,
-        ArgumentMetadata(
-            display_name="Model",
-            description="Deployment name of the model to use.",
-        ),
-    ],
     prompt: Annotated[
         str,
         ArgumentMetadata(
@@ -61,8 +54,9 @@ def azure_openai_chat_completion(
     secret = ctx.get().secrets.get("AZURE_OPENAI_SECRET")
     endpoint = secret["endpoint"]
     api_key = secret["api_key"]
+    model = secret["deployment_name"]
 
-    client = AzureOpenAI(api_version="2024-06-01", endpoint=endpoint, api_key=api_key)
+    client = AzureOpenAI(api_version="2024-06-01", azure_endpoint=endpoint, api_key=api_key)
     chat_completion = client.chat.completions.create(
         messages=[{"role": "user", "content": prompt}],
         model=model,

--- a/docs/pages/integrations/azure_openai/azure_openai.mdx
+++ b/docs/pages/integrations/azure_openai/azure_openai.mdx
@@ -12,7 +12,7 @@
 
 ![Azure OAI Studio](/azure_oai_deploy_model.png)
 
-5. Deploy the model of your choice. The name of the model deployment is used as model parameter for the actions.
+5. Deploy the model of your choice. The **name of the model deployment** is a used when defining **Credentials** in **Admyral**.
 
 6. Next, go back to your [Azure Portal](https://portal.azure.com) and go to the subscription which contains the Azure OpenAI deployment.
 
@@ -30,15 +30,16 @@
 
 11. The following secrets structure is expected:
 
-| Key        | Value                                    |
-| ---------- | ---------------------------------------- |
-| `api_key`  | Paste the **API key** here               |
-| `endpoint` | Paste the **Azure OpenAI endpoint** here |
+| Key               | Value                                    |
+| ----------------- | ---------------------------------------- |
+| `api_key`         | Paste the **API key** here               |
+| `endpoint`        | Paste the **Azure OpenAI endpoint** here |
+| `deployment_name` | Paste the **model deployment name** here |
 
 12. Click on the **Save** button.
 
 Alternatively, you can use the following CLI command structure:
 
 ```bash
-admyral secret set azure_openai_secret --value api_key=your_key_value --value endpoint=your_endpoint
+admyral secret set azure_openai_secret --value api_key=your_key_value --value endpoint=your_endpoint --value deployment_name=your_deployment_name
 ```


### PR DESCRIPTION
Fix AzureOpenAI constructor parameter name, moved model deployment param to the secret instead of the action.

## What does this PR do?

- Fix AzureOpenAI constructor parameter name : this fixes the `AzureOpenAI.__init__() got an unexpected keyword argument 'endpoint'`error message when calling Azure OpenAI actions.
- Moved model deployment param to the secret instead of the action. The API key, stored in the secret, is linked to the deployment name in Azure, so it makes more sense to tie them together.


## Type of change

<!-- Please delete bullets that are not relevant. -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [x] Chore (refactoring code, technical debt, workflow improvements)
-   [x] This change requires a documentation update

## Mandatory Tasks

-   [ ] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

<!-- Remove bullet points below that don't apply to you -->

-   I haven't checked if my changes generate no new warnings (`npm run lint`)
-   I haven't added tests that prove my fix is effective or that my feature works
-   I haven't checked if new and existing unit tests pass locally with my changes
    -   Inside backend: `poetry run pytest`
    -   Inside workflow-runner: `cargo test`
