### PR TITLE
Add get_okta_logs documentation

### DIFF
--- a/admyral/actions/integrations/iam/okta.py
+++ b/admyral/actions/integrations/iam/okta.py
@@ -214,6 +214,7 @@ def get_okta_logs(
         ),
     ] = 1000,
 ) -> list[dict[str, JsonValue]]:
+    # https://developer.okta.com/docs/api/openapi/okta-management/management/tag/SystemLog/#tag/SystemLog/operation/listLogEvents
     secret = ctx.get().secrets.get("OKTA_SECRET")
     okta_domain = secret["domain"]
     api_key = secret["api_key"]

--- a/docs/pages/integrations/okta/apis/get_all_user_types.mdx
+++ b/docs/pages/integrations/okta/apis/get_all_user_types.mdx
@@ -5,8 +5,8 @@ import { Callout } from "nextra/components";
 Retrieve all user types from Okta.
 
 <Callout type="info">
-	For more information on setting up Okta API tokens, see [Okta
-	Documentation](https://developer.okta.com/docs/reference/api/user-types/).
+	For more information on the API for listing user types, see [List all User
+	Types](https://developer.okta.com/docs/api/openapi/okta-management/management/tag/UserType/).
 </Callout>
 
 **SDK Import:**

--- a/docs/pages/integrations/okta/apis/get_logs.mdx
+++ b/docs/pages/integrations/okta/apis/get_logs.mdx
@@ -1,0 +1,44 @@
+import { Callout } from "nextra/components";
+
+# Get Logs (Okta)
+
+Retrieve a list of system log events events from Okta.
+
+<Callout type="info">
+	For more information on the API for listing system log events, see [List all
+	System Log
+	Events](https://developer.okta.com/docs/api/openapi/okta-management/management/tag/SystemLog/#tag/SystemLog/operation/listLogEvents).
+</Callout>
+
+**SDK Import:**
+
+```python
+from admyral.actions import get_okta_logs
+```
+
+## Arguments:
+
+| Argument Name               | Description                                                                               | Required |
+| --------------------------- | ----------------------------------------------------------------------------------------- | :------: |
+| **Query** `query`           | Filter log events by specified keywords.                                                  |    -     |
+| **Start Time** `start_time` | The start time for the events to list. Must be in ISO 8601 format (YYYY-MM-DDTHH:MM:SSZ). |    -     |
+| **End Time** `end_time`     | The end time for the events to list. Must be in ISO 8601 format (YYYY-MM-DDTHH:MM:SSZ).   |    -     |
+| **Limit** `limit`           | The maximum number of events to retrieve. Default: 1000                                   |    -     |
+
+## Returns
+
+A JSON array of events.
+
+## Required Secrets
+
+| Secret Placeholder | Description                                            |
+| ------------------ | ------------------------------------------------------ |
+| `OKTA_SECRET`      | Okta secret. See [Okta setup](/integrations/okta/okta) |
+
+## SDK Example
+
+```python
+events = get_okta_logs(
+	secrets={"OKTA_SECRET": "my_stored_okta_secret"}
+)
+```

--- a/docs/pages/integrations/okta/apis/get_logs.mdx
+++ b/docs/pages/integrations/okta/apis/get_logs.mdx
@@ -20,7 +20,7 @@ from admyral.actions import get_okta_logs
 
 | Argument Name               | Description                                                                               | Required |
 | --------------------------- | ----------------------------------------------------------------------------------------- | :------: |
-| **Query** `query`           | Filter log events by specified keywords. Example: `San Francisco`                         |    -     |
+| **Query** `query`           | Filter log events by specified keywords. Example: `policy.lifecycle.update Password`      |    -     |
 | **Start Time** `start_time` | The start time for the events to list. Must be in ISO 8601 format (YYYY-MM-DDTHH:MM:SSZ). |    -     |
 | **End Time** `end_time`     | The end time for the events to list. Must be in ISO 8601 format (YYYY-MM-DDTHH:MM:SSZ).   |    -     |
 | **Limit** `limit`           | The maximum number of events to retrieve. Default: 1000                                   |    -     |

--- a/docs/pages/integrations/okta/apis/get_logs.mdx
+++ b/docs/pages/integrations/okta/apis/get_logs.mdx
@@ -20,7 +20,7 @@ from admyral.actions import get_okta_logs
 
 | Argument Name               | Description                                                                               | Required |
 | --------------------------- | ----------------------------------------------------------------------------------------- | :------: |
-| **Query** `query`           | Filter log events by specified keywords.                                                  |    -     |
+| **Query** `query`           | Filter log events by specified keywords. Example: `San Francisco`                         |    -     |
 | **Start Time** `start_time` | The start time for the events to list. Must be in ISO 8601 format (YYYY-MM-DDTHH:MM:SSZ). |    -     |
 | **End Time** `end_time`     | The end time for the events to list. Must be in ISO 8601 format (YYYY-MM-DDTHH:MM:SSZ).   |    -     |
 | **Limit** `limit`           | The maximum number of events to retrieve. Default: 1000                                   |    -     |

--- a/docs/pages/integrations/okta/apis/list_events.mdx
+++ b/docs/pages/integrations/okta/apis/list_events.mdx
@@ -5,8 +5,8 @@ import { Callout } from "nextra/components";
 Retrieve a list of events from Okta within a specified time range. This API allows filtering events by user ID and supports pagination for large datasets.
 
 <Callout type="info">
-	For more information on setting up Okta API tokens, see [Okta
-	Documentation](https://developer.okta.com/docs/reference/api/system-log/#list-events).
+	For more information on the API for listing events, see [List
+	events](https://developer.okta.com/docs/reference/api/system-log/#list-events).
 </Callout>
 
 **SDK Import:**

--- a/docs/pages/integrations/okta/apis/search_users.mdx
+++ b/docs/pages/integrations/okta/apis/search_users.mdx
@@ -5,8 +5,8 @@ import { Callout } from "nextra/components";
 Search for users in Okta based on a search query.
 
 <Callout type="info">
-	For more information on setting up Okta API tokens, see [Okta
-	Documentation](https://developer.okta.com/docs/reference/api/users/#list-users-with-search).
+	For more information on the API for searching users, see [Search
+	users](https://developer.okta.com/docs/reference/user-query/#search-users).
 </Callout>
 
 **SDK Import:**


### PR DESCRIPTION
This PR adds documentation for the get_okta_logs action. It also includes minor updates for existing documentation for okta API actions.