### PR TITLE
Add API reference to action definition and update Callouts in corresponding doc pages

### DIFF
--- a/admyral/actions/ai_action.py
+++ b/admyral/actions/ai_action.py
@@ -47,6 +47,7 @@ def ai_action(
         ),
     ] = None,
 ) -> str:
+    # # https://platform.openai.com/docs/api-reference/chat/create
     api_key = os.environ.get("OPENAI_API_KEY")
     if not api_key:
         raise ValueError(

--- a/admyral/actions/ai_action.py
+++ b/admyral/actions/ai_action.py
@@ -47,7 +47,7 @@ def ai_action(
         ),
     ] = None,
 ) -> str:
-    # # https://platform.openai.com/docs/api-reference/chat/create
+    # https://platform.openai.com/docs/api-reference/chat/create
     api_key = os.environ.get("OPENAI_API_KEY")
     if not api_key:
         raise ValueError(

--- a/admyral/actions/integrations/ai/anthropic.py
+++ b/admyral/actions/integrations/ai/anthropic.py
@@ -63,6 +63,7 @@ def anthropic_chat_completion(
         ),
     ] = None,
 ) -> str:
+    # https://docs.anthropic.com/en/api/messages
     # TODO: error handling
     secret = ctx.get().secrets.get("ANTHROPIC_SECRET")
     api_key = secret["api_key"]

--- a/admyral/actions/integrations/ai/azure_openai.py
+++ b/admyral/actions/integrations/ai/azure_openai.py
@@ -49,6 +49,7 @@ def azure_openai_chat_completion(
         ),
     ] = None,
 ) -> str:
+    # https://learn.microsoft.com/en-us/azure/ai-services/openai/how-to/chatgpt?tabs=python-new#work-with-chat-completion-models
     # TODO: add authentication via Entra ID: https://github.com/openai/openai-python/blob/main/examples/azure_ad.py
     # TODO: error handling
     secret = ctx.get().secrets.get("AZURE_OPENAI_SECRET")

--- a/admyral/actions/integrations/ai/mistralai.py
+++ b/admyral/actions/integrations/ai/mistralai.py
@@ -55,6 +55,7 @@ def mistralai_chat_completion(
         ),
     ] = None,
 ) -> str:
+    # https://docs.mistral.ai/api/#tag/chat
     # TODO: error handling
     secret = ctx.get().secrets.get("MISTRALAI_SECRET")
     api_key = secret["api_key"]

--- a/admyral/actions/integrations/ai/openai.py
+++ b/admyral/actions/integrations/ai/openai.py
@@ -55,6 +55,7 @@ def openai_chat_completion(
         ),
     ] = None,
 ) -> str:
+    # https://platform.openai.com/docs/api-reference/chat/create
     # TODO: error handling
     secret = ctx.get().secrets.get("OPENAI_SECRET")
     api_key = secret["api_key"]

--- a/admyral/actions/integrations/cdr/ms_defender_for_cloud.py
+++ b/admyral/actions/integrations/cdr/ms_defender_for_cloud.py
@@ -39,6 +39,7 @@ def list_ms_defender_for_cloud_alerts(
         ),
     ] = 1000,
 ) -> list[dict[str, JsonValue]]:
+    # https://learn.microsoft.com/en-us/rest/api/defenderforcloud/alerts/list?view=rest-defenderforcloud-2022-01-01&tabs=HTTP
     secret = ctx.get().secrets.get("AZURE_SECRET")
     return ms_graph_list_alerts_v2(
         tenant_id=secret["tenant_id"],

--- a/admyral/actions/integrations/communication/slack.py
+++ b/admyral/actions/integrations/communication/slack.py
@@ -53,6 +53,7 @@ def send_slack_message(
         ),
     ] = None,
 ) -> JsonValue:
+    # https://api.slack.com/methods/chat.postMessage
     secret = ctx.get().secrets.get("SLACK_SECRET")
     api_key = secret["api_key"]
 
@@ -93,6 +94,7 @@ def lookup_slack_user_by_email(
         ),
     ],
 ) -> str:
+    # https://api.slack.com/methods/users.lookupByEmail
     secret = ctx.get().secrets.get("SLACK_SECRET")
     api_key = secret["api_key"]
 
@@ -132,6 +134,7 @@ def send_slack_message_to_user_by_email(
         ),
     ] = None,
 ) -> JsonValue:
+    # https://api.slack.com/methods/chat.postMessage
     # https://api.slack.com/methods/users.lookupByEmail
 
     secret = ctx.get().secrets.get("SLACK_SECRET")
@@ -168,6 +171,8 @@ def batched_send_slack_message_to_user_by_email(
         ),
     ],
 ) -> JsonValue:
+    # https://api.slack.com/methods/chat.postMessage
+    # https://api.slack.com/methods/users.lookupByEmail
     for email, text, blocks in messages:
         try:
             send_slack_message_to_user_by_email(email=email, text=text, blocks=blocks)

--- a/admyral/actions/integrations/compliance/retool.py
+++ b/admyral/actions/integrations/compliance/retool.py
@@ -74,6 +74,7 @@ def list_retool_inactive_users(
 )
 def list_groups_per_user() -> dict[str, JsonValue]:
     # Get all permission groups for an organization or space. The API token must have the "Groups > Read" scope.
+    # https://docs.retool.com/reference/api/#tag/Users/paths/~1users~1%7BuserId%7D/patch
     # https://docs.retool.com/reference/api/v2/#tag/Groups/paths/~1groups~1%7BgroupId%7D/put
 
     secret = ctx.get().secrets.get("RETOOL_SECRET")

--- a/admyral/actions/integrations/edr/sentinel_one.py
+++ b/admyral/actions/integrations/edr/sentinel_one.py
@@ -46,7 +46,7 @@ def list_sentinel_one_alerts(
         ),
     ] = 1000,
 ) -> list[dict[str, JsonValue]]:
-    # https://github.com/fragtastic/sentinelone-api-python/blob/main/sentineloneapi/client.py
+    # https://github.com/fragtastic/sentinelone-api-python/blob/67f8005576a6613f925edca93e22c8da7d6c3010/sentineloneapi/client.py#L98
 
     secret = ctx.get().secrets.get("SENTINEL_ONE_SECRET")
     base_url = secret["base_url"]

--- a/admyral/actions/integrations/enrich/alienvault_otx.py
+++ b/admyral/actions/integrations/enrich/alienvault_otx.py
@@ -32,6 +32,7 @@ def alienvault_otx_analyze_domain(
         ),
     ],
 ) -> JsonValue:
+    # https://otx.alienvault.com/assets/static/external_api.html
     secret = ctx.get().secrets.get("ALIENVAULT_OTX_SECRET")
     api_key = secret["api_key"]
 

--- a/admyral/actions/integrations/enrich/greynoise.py
+++ b/admyral/actions/integrations/enrich/greynoise.py
@@ -31,6 +31,7 @@ def grey_noise_ip_lookup(
         ),
     ],
 ) -> JsonValue:
+    # https://docs.greynoise.io/reference/get_v3-community-ip
     secret = ctx.get().secrets.get("GREY_NOISE_SECRET")
     api_key = secret["api_key"]
     with get_grey_noise_client(api_key) as client:

--- a/admyral/actions/integrations/enrich/virus_total.py
+++ b/admyral/actions/integrations/enrich/virus_total.py
@@ -33,6 +33,7 @@ def virus_total_analyze_hash(
         ),
     ],
 ) -> JsonValue:
+    # https://docs.virustotal.com/reference/file-info
     secret = ctx.get().secrets.get("VIRUS_TOTAL_SECRET")
     api_key = secret["api_key"]
     with get_virus_total_client(api_key) as client:
@@ -56,6 +57,7 @@ def virus_total_analyze_domain(
         ),
     ],
 ) -> JsonValue:
+    # https://docs.virustotal.com/reference/domain-info
     secret = ctx.get().secrets.get("VIRUS_TOTAL_SECRET")
     api_key = secret["api_key"]
     with get_virus_total_client(api_key) as client:
@@ -78,6 +80,7 @@ def virus_total_analyze_ip(
         ),
     ],
 ) -> JsonValue:
+    # https://developers.virustotal.com/reference/ip-addresses
     secret = ctx.get().secrets.get("VIRUS_TOTAL_SECRET")
     api_key = secret["api_key"]
     with get_virus_total_client(api_key) as client:
@@ -101,6 +104,7 @@ def virus_total_analyze_url(
         ),
     ],
 ) -> JsonValue:
+    # https://docs.virustotal.com/reference/url-info
     secret = ctx.get().secrets.get("VIRUS_TOTAL_SECRET")
     api_key = secret["api_key"]
     with get_virus_total_client(api_key) as client:

--- a/admyral/actions/integrations/iam/okta.py
+++ b/admyral/actions/integrations/iam/okta.py
@@ -73,7 +73,7 @@ def list_okta_events(
     ] = 1000,
 ) -> list[dict[str, JsonValue]]:
     # Note: Bounded Request - Polling Request use case not supported
-    # https://developer.okta.com/docs/reference/api/system-log/
+    # https://developer.okta.com/docs/reference/api/system-log/#list-events
 
     secret = ctx.get().secrets.get("OKTA_SECRET")
     okta_domain = secret["domain"]
@@ -129,6 +129,7 @@ def okta_search_users(
         ),
     ] = 1000,
 ) -> list[dict[str, JsonValue]]:
+    # https://developer.okta.com/docs/api/openapi/okta-management/management/tag/User/#tag/User/operation/listUsers
     secret = ctx.get().secrets.get("OKTA_SECRET")
     okta_domain = secret["domain"]
     api_key = secret["api_key"]
@@ -165,6 +166,7 @@ def okta_search_users(
     secrets_placeholders=["OKTA_SECRET"],
 )
 def okta_get_all_user_types() -> list[dict[str, JsonValue]]:
+    # https://developer.okta.com/docs/api/openapi/okta-management/management/tag/UserType/#tag/UserType/operation/listUserTypes
     secret = ctx.get().secrets.get("OKTA_SECRET")
     okta_domain = secret["domain"]
     api_key = secret["api_key"]

--- a/admyral/actions/send_email.py
+++ b/admyral/actions/send_email.py
@@ -44,6 +44,7 @@ def send_email(
         ),
     ],
 ) -> JsonValue:
+    # https://resend.com/docs/api-reference/emails/send-email
     RESEND_EMAIL = os.getenv("RESEND_EMAIL")
 
     if not resend.api_key:

--- a/docs/pages/integrations/1password/apis/list_audit_events.mdx
+++ b/docs/pages/integrations/1password/apis/list_audit_events.mdx
@@ -6,8 +6,8 @@ This endpoint returns information about actions performed by team members within
 along with details about the type and object of the action and any other information about the activity.
 
 <Callout type="info">
-	For more information on the 1Password API, see [1Password
-	Documentation](https://developer.1password.com/docs/events-api/reference/#post-apiv1auditevents).
+	For more information on the API for listing audit events, see
+	[auditevents](https://developer.1password.com/docs/events-api/reference/#post-apiv1auditevents).
 </Callout>
 
 **SDK Import:**

--- a/docs/pages/integrations/abnormal/apis/list_cases.mdx
+++ b/docs/pages/integrations/abnormal/apis/list_cases.mdx
@@ -5,8 +5,8 @@ import { Callout } from "nextra/components";
 Get a list of Abnormal cases identified by Abnormal Security.
 
 <Callout type="info">
-	For Abnormal's documentation, see [Abnormal List Cases
-	API](https://app.swaggerhub.com/apis-docs/abnormal-security/abx/1.4.3#/Cases/get_cases).
+	For more information on the API for listing cases, see
+	[Cases](https://app.swaggerhub.com/apis-docs/abnormal-security/abx/1.4.3#/Cases/get_cases).
 </Callout>
 
 **SDK Import:**

--- a/docs/pages/integrations/abuseipdb/apis/check_ip.mdx
+++ b/docs/pages/integrations/abuseipdb/apis/check_ip.mdx
@@ -5,7 +5,7 @@ import { Callout } from "nextra/components";
 Retrieve detailed information about the reputation of a specific IP address.
 
 <Callout type="info">
-	For AbuseIPDB's documentation, see [CHECK
+	For more information on the API for checking an IP address, see [CHECK
 	Endpoint](https://docs.abuseipdb.com/#check-endpoint).
 </Callout>
 

--- a/docs/pages/integrations/alien_vault/apis/analyze_domain.mdx
+++ b/docs/pages/integrations/alien_vault/apis/analyze_domain.mdx
@@ -5,7 +5,7 @@ import { Callout } from "nextra/components";
 Analyze a domain using AlienVault OTX (Open Threat Exchange) to gather threat intelligence and general information associated with the specified domain.
 
 <Callout type="info">
-	For more information on the AlienVault OTX API, see [AlienVault OTX
+	For more information on the API for analyzing a domain, see [AlienVault OTX
 	Documentation](https://otx.alienvault.com/assets/static/external_api.html).
 </Callout>
 

--- a/docs/pages/integrations/anthropic/apis/chat_completion.mdx
+++ b/docs/pages/integrations/anthropic/apis/chat_completion.mdx
@@ -5,8 +5,8 @@ import { Callout } from "nextra/components";
 Leverage advanced AI models from Anthropic to perform complex tasks such as categorization, analysis, summarization, or decision support.
 
 <Callout type="info">
-	For more information on Anthropic's API, see [Anthropic
-	Documentation](https://docs.anthropic.com).
+	For more information on the API for chat completion, see [Create a
+	Message](https://docs.anthropic.com/en/api/messages).
 </Callout>
 
 **SDK Import:**

--- a/docs/pages/integrations/azure_openai/apis/chat_completion.mdx
+++ b/docs/pages/integrations/azure_openai/apis/chat_completion.mdx
@@ -5,8 +5,9 @@ import { Callout } from "nextra/components";
 Leverage advanced AI models from Azure OpenAI to perform complex tasks such as categorization, analysis, summarization, or decision support.
 
 <Callout type="info">
-	For more information on Azure OpenAI's API, see [Azure OpenAI
-	Documentation](https://learn.microsoft.com/en-us/azure/ai-services/openai/).
+	For more information on the API for chat completion, see [Work with chat
+	completion
+	models](https://learn.microsoft.com/en-us/azure/ai-services/openai/how-to/chatgpt?tabs=python-new#work-with-chat-completion-models).
 </Callout>
 
 **SDK Import:**

--- a/docs/pages/integrations/greynoise/apis/ip_lookup.mdx
+++ b/docs/pages/integrations/greynoise/apis/ip_lookup.mdx
@@ -5,7 +5,8 @@ import { Callout } from "nextra/components";
 Lookup information about an IP address using GreyNoise.
 
 <Callout type="info">
-	For GreyNoise's documentation, see [GreyNoise IP Lookup via Community
+	For more information on the API for looking up an IP, see [GreyNoise IP
+	Lookup via Community
 	API](https://docs.greynoise.io/reference/get_v3-community-ip).
 </Callout>
 

--- a/docs/pages/integrations/jira/apis/comment_issue.mdx
+++ b/docs/pages/integrations/jira/apis/comment_issue.mdx
@@ -5,8 +5,8 @@ import { Callout } from "nextra/components";
 Adds a comment to an issue.
 
 <Callout type="info">
-	For Jira's documentation, see [Add
-	Comment](https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-comments/#api-rest-api-3-issue-issueidorkey-comment-post).
+	For more information on the API for commenting an issue, see [Add
+	comment](https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-comments/#api-rest-api-3-issue-issueidorkey-comment-post).
 </Callout>
 
 **SDK Import:**

--- a/docs/pages/integrations/jira/apis/create_issue.mdx
+++ b/docs/pages/integrations/jira/apis/create_issue.mdx
@@ -5,8 +5,8 @@ import { Callout } from "nextra/components";
 Create a new Jira issue.
 
 <Callout type="info">
-	For Jira's documentation, see [Create
-	Issue](https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issues/#api-rest-api-3-issue-post).
+	For more information on the API for creating an Issue, see [Create
+	issue](https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issues/#api-rest-api-3-issue-post).
 </Callout>
 
 **SDK Import:**

--- a/docs/pages/integrations/jira/apis/get_audit_records.mdx
+++ b/docs/pages/integrations/jira/apis/get_audit_records.mdx
@@ -5,7 +5,7 @@ import { Callout } from "nextra/components";
 Get Jira audit records.
 
 <Callout type="info">
-	For Jira's documentation, see [Get audit
+	For more information on the API for getting audit records, see [Get audit
 	records](https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-audit-records/#api-rest-api-3-auditing-record-get).
 </Callout>
 

--- a/docs/pages/integrations/jira/apis/search_issues.mdx
+++ b/docs/pages/integrations/jira/apis/search_issues.mdx
@@ -5,7 +5,8 @@ import { Callout } from "nextra/components";
 Search Jira issues.
 
 <Callout type="info">
-	For Jira's documentation, see [Search for issues using
+	For more information on the API for searching issues, see [Search for issues
+	using
 	JQL](https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-search/#api-rest-api-3-search-get).
 </Callout>
 

--- a/docs/pages/integrations/jira/apis/update_issue_status.mdx
+++ b/docs/pages/integrations/jira/apis/update_issue_status.mdx
@@ -5,7 +5,8 @@ import { Callout } from "nextra/components";
 Transitions an issue to a new status.
 
 <Callout type="info">
-	For Jira's documentation, see [Transition
+	For more information on the API for updating an issue status, see
+	[Transition
 	Issue](https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issues/#api-rest-api-3-issue-issueidorkey-transitions-post).
 </Callout>
 

--- a/docs/pages/integrations/mistral/apis/chat_completion.mdx
+++ b/docs/pages/integrations/mistral/apis/chat_completion.mdx
@@ -5,7 +5,7 @@ import { Callout } from "nextra/components";
 Leverage advanced AI models from Mistral AI to perform complex tasks such as categorization, analysis, summarization, or decision support.
 
 <Callout type="info">
-	For more information on Mistral AI's API, see [Mistral AI Chat
+	For more information on Mistral AI's API for chat completion, see [Chat
 	Completion](https://docs.mistral.ai/api/#tag/chat/operation/chat_completion_v1_chat_completions_post).
 </Callout>
 

--- a/docs/pages/integrations/ms_defender_for_cloud/apis/list_alerts.mdx
+++ b/docs/pages/integrations/ms_defender_for_cloud/apis/list_alerts.mdx
@@ -5,7 +5,7 @@ import { Callout } from "nextra/components";
 List alerts from Microsoft Defender for Cloud.
 
 <Callout type="info">
-	For Microsoft Defender for Cloud's documentation, see [List
+	For more information on the API for listing alerts, see [List
 	Alerts](https://learn.microsoft.com/en-us/rest/api/defenderforcloud/alerts/list?view=rest-defenderforcloud-2022-01-01&tabs=HTTP).
 </Callout>
 

--- a/docs/pages/integrations/openai/apis/chat_completion.mdx
+++ b/docs/pages/integrations/openai/apis/chat_completion.mdx
@@ -5,8 +5,8 @@ import { Callout } from "nextra/components";
 Leverage advanced AI models from OpenAI to perform complex tasks such as categorization, analysis, summarization, or decision support.
 
 <Callout type="info">
-	For more information on OpenAI's API, see [OpenAI
-	Documentation](https://platform.openai.com/docs/api-reference/chat/create).
+	For more information on the API for chat completion, see [Create a chat
+	completion](https://platform.openai.com/docs/api-reference/chat/create).
 </Callout>
 
 **SDK Import:**

--- a/docs/pages/integrations/opsgenie/apis/create_alert.mdx
+++ b/docs/pages/integrations/opsgenie/apis/create_alert.mdx
@@ -5,7 +5,7 @@ import { Callout } from "nextra/components";
 Create an alert in Opsgenie.
 
 <Callout type="info">
-	For Opsgenie's documentation, see [Create
+	For more information on the API for creating an alert, see [Create
 	Alert](https://docs.opsgenie.com/docs/alert-api#section-create-alert).
 </Callout>
 

--- a/docs/pages/integrations/pagerduty/apis/create_incident.mdx
+++ b/docs/pages/integrations/pagerduty/apis/create_incident.mdx
@@ -5,8 +5,8 @@ import { Callout } from "nextra/components";
 Create a new incident in PagerDuty using the provided incident details such as title, service ID, urgency, and optional assignees.
 
 <Callout type="info">
-	For more information on the PagerDuty API, see [PagerDuty Incident Creation
-	API](https://developer.pagerduty.com/docs/ZG9jOjExMDI5NTY0-incident-creation-api).
+	For more information on the API for creating an incident, see [Create an
+	Incident](https://developer.pagerduty.com/docs/ZG9jOjExMDI5NTY0-incident-creation-api).
 </Callout>
 
 **SDK Import:**

--- a/docs/pages/integrations/retool/apis/list_groups_per_user.mdx
+++ b/docs/pages/integrations/retool/apis/list_groups_per_user.mdx
@@ -5,8 +5,10 @@ import { Callout } from "nextra/components";
 This method lists all groups a user is a member of, along with the last time a user was active in Retool. It helps administrators understand which groups users belong to and their activity levels.
 
 <Callout type="info">
-	For more information on the Retool API, see [Retool API
-	Documentation](https://docs.retool.com/reference/api).
+	For more information on the API for listing groups per user, see [List
+	users](https://docs.retool.com/reference/api/#tag/Users/paths/~1users~1%7BuserId%7D/patch)
+	and [List
+	groups](https://docs.retool.com/reference/api/v2/#tag/Groups/paths/~1groups~1%7BgroupId%7D/put).
 </Callout>
 
 **SDK Import:**

--- a/docs/pages/integrations/retool/apis/list_inactive_users.mdx
+++ b/docs/pages/integrations/retool/apis/list_inactive_users.mdx
@@ -5,8 +5,8 @@ import { Callout } from "nextra/components";
 This method lists Retool users who have not logged in for a specified number of days. It helps identify users who are inactive and may no longer need access.
 
 <Callout type="info">
-	For more information on the Retool API, see [Retool API
-	Documentation](https://docs.retool.com/reference/api).
+	For more information on the API for listing users, see [List
+	users](https://docs.retool.com/reference/api/#tag/Users/paths/~1users~1%7BuserId%7D/patch).
 </Callout>
 
 **SDK Import:**

--- a/docs/pages/integrations/sentinel_one/apis/list_alerts.mdx
+++ b/docs/pages/integrations/sentinel_one/apis/list_alerts.mdx
@@ -5,8 +5,8 @@ import { Callout } from "nextra/components";
 Retrieve a list of alerts from SentinelOne within a specified time range. The API allows you to filter alerts based on their creation time and set a limit on the number of results.
 
 <Callout type="info">
-	For more information on the SentinelOne API, see [SentinelOne API
-	Documentation](https://github.com/fragtastic/sentinelone-api-python/blob/main/sentineloneapi/client.py).
+	For more information on the API for listing alerts, see [Get
+	Alerts](https://github.com/fragtastic/sentinelone-api-python/blob/67f8005576a6613f925edca93e22c8da7d6c3010/sentineloneapi/client.py#L98).
 </Callout>
 
 **SDK Import:**

--- a/docs/pages/integrations/slack/apis/batched_send_message_to_user_by_email.mdx
+++ b/docs/pages/integrations/slack/apis/batched_send_message_to_user_by_email.mdx
@@ -5,9 +5,9 @@ import { Callout } from "nextra/components";
 Send a batch of messages where each message is sent to its own defined user.
 
 <Callout type="info">
-	For Slack's documentation, see
-	[users.lookupByEmail](https://api.slack.com/methods/users.lookupByEmail) and
-	[chat.postMessage](https://api.slack.com/methods/chat.postMessage).
+	For more information on the API for sending a message to a user by email,
+	see [users.lookupByEmail](https://api.slack.com/methods/users.lookupByEmail)
+	and [chat.postMessage](https://api.slack.com/methods/chat.postMessage).
 </Callout>
 
 **SDK Import:**

--- a/docs/pages/integrations/slack/apis/lookup_by_email.mdx
+++ b/docs/pages/integrations/slack/apis/lookup_by_email.mdx
@@ -9,7 +9,7 @@ Required scopes:
 -   `users:read.email`
 
 <Callout type="info">
-	For Slack's documentation, see
+	For more information on the API for looking up a user by email, see
 	[users.lookupByEmail](https://api.slack.com/methods/users.lookupByEmail).
 </Callout>
 

--- a/docs/pages/integrations/slack/apis/send_message.mdx
+++ b/docs/pages/integrations/slack/apis/send_message.mdx
@@ -9,7 +9,7 @@ Required scopes:
 -   `chat:write`
 
 <Callout type="info">
-	For Slack's documentation, see
+	For more information on the API for sending a message, see
 	[chat.postMessage](https://api.slack.com/methods/chat.postMessage).
 </Callout>
 

--- a/docs/pages/integrations/slack/apis/send_message_to_user_by_email.mdx
+++ b/docs/pages/integrations/slack/apis/send_message_to_user_by_email.mdx
@@ -5,9 +5,9 @@ import { Callout } from "nextra/components";
 Send a user identified by email a Slack message.
 
 <Callout type="info">
-	For Slack's documentation, see
-	[users.lookupByEmail](https://api.slack.com/methods/users.lookupByEmail) and
-	[chat.postMessage](https://api.slack.com/methods/chat.postMessage).
+	For more information on the API for sending a message to a user by email,
+	see [users.lookupByEmail](https://api.slack.com/methods/users.lookupByEmail)
+	and [chat.postMessage](https://api.slack.com/methods/chat.postMessage).
 </Callout>
 
 **SDK Import:**

--- a/docs/pages/integrations/virus_total/apis/analyze_domain.mdx
+++ b/docs/pages/integrations/virus_total/apis/analyze_domain.mdx
@@ -5,8 +5,8 @@ import { Callout } from "nextra/components";
 Retrieve information about a domain.
 
 <Callout type="info">
-	For VirusTotal's documentation, see [Get Domain
-	Info](https://docs.virustotal.com/reference/domain-info).
+	For more information on the API for analyzing a domain, see [Get a domain
+	report](https://docs.virustotal.com/reference/domain-info).
 </Callout>
 
 **SDK Import:**

--- a/docs/pages/integrations/virus_total/apis/analyze_hash.mdx
+++ b/docs/pages/integrations/virus_total/apis/analyze_hash.mdx
@@ -5,8 +5,8 @@ import { Callout } from "nextra/components";
 Retrieve detailed information about a file hash from VirusTotal.
 
 <Callout type="info">
-	For VirusTotal's documentation, see [Retrieve File
-	Information](https://docs.virustotal.com/reference/file-info).
+	For more information on the API for analyzing a file hash, see [Get a file
+	report](https://docs.virustotal.com/reference/file-info).
 </Callout>
 
 **SDK Import:**

--- a/docs/pages/integrations/virus_total/apis/analyze_ip.mdx
+++ b/docs/pages/integrations/virus_total/apis/analyze_ip.mdx
@@ -5,8 +5,8 @@ import { Callout } from "nextra/components";
 Retrieve detailed information about a specific IP address.
 
 <Callout type="info">
-	For VirusTotal's documentation, see [Get IP Address
-	Report](https://developers.virustotal.com/reference/ip-addresses).
+	For more information on the API for analyzing an IP address, see [Get an IP
+	address report](https://developers.virustotal.com/reference/ip-addresses).
 </Callout>
 
 **SDK Import:**

--- a/docs/pages/integrations/virus_total/apis/analyze_url.mdx
+++ b/docs/pages/integrations/virus_total/apis/analyze_url.mdx
@@ -5,8 +5,8 @@ import { Callout } from "nextra/components";
 Retrieve detailed information about a URL.
 
 <Callout type="info">
-	For VirusTotal's documentation, see [URL
-	Info](https://docs.virustotal.com/reference/url-info).
+	For more information on the API for analyzing a URL, see [Get a URL analysis
+	report](https://docs.virustotal.com/reference/url-info).
 </Callout>
 
 **SDK Import:**

--- a/docs/pages/integrations/wiz/apis/list_alerts.mdx
+++ b/docs/pages/integrations/wiz/apis/list_alerts.mdx
@@ -5,14 +5,14 @@ import { Callout } from "nextra/components";
 List alerts from Wiz with filtering options for time range, status, severity, and type. If no time range is provided, the alerts from the last 24 hours will be listed.
 
 <Callout type="info">
-	For more information on the Wiz API, see [Wiz
+	For more information on the API for listing alerts, see [Wiz
 	Documentation](https://docs.wiz.io/docs).
 </Callout>
 
 **SDK Import:**
 
 ```python
-from admyral.actions import virus_total_analyze_url
+from admyral.actions import list_wiz_alerts
 ```
 
 ## Arguments:


### PR DESCRIPTION
This PR adds, where appropriate / possible comments with API references used within the action.
Additionally, the callouts throughout the API are adjusted to follow the same schema and have the correct API reference linked.