### PR TITLE
Add control mapping to workflows

### DIFF
--- a/admyral/compiler/workflow_compiler.py
+++ b/admyral/compiler/workflow_compiler.py
@@ -157,6 +157,7 @@ class WorkflowCompiler:
         return WorkflowDAG(
             name=workflow.name,
             description=workflow.description,
+            controls=workflow.controls,
             start=WorkflowStart(
                 triggers=self._handle_triggers(workflow),
             ),

--- a/admyral/db/schemas/workflow_schemas.py
+++ b/admyral/db/schemas/workflow_schemas.py
@@ -81,6 +81,7 @@ class WorkflowSchema(BaseSchema, table=True):
             workflow_id=self.workflow_id,
             workflow_name=self.workflow_name,
             workflow_description=self.workflow_dag.get("description"),
+            controls=self.workflow_dag.get("controls"),
             created_at=self.created_at,
             is_active=self.is_active,
         )

--- a/admyral/editor/graph_conversion.py
+++ b/admyral/editor/graph_conversion.py
@@ -125,6 +125,7 @@ def workflow_to_editor_workflow_graph(
         workflow_id=workflow.workflow_id,
         workflow_name=workflow.workflow_name,
         description=workflow.workflow_dag.description,
+        controls=workflow.workflow_dag.controls,
         is_active=workflow.is_active,
         nodes=nodes,
         edges=edges,
@@ -205,6 +206,7 @@ def editor_workflow_graph_to_workflow(
         workflow_dag=WorkflowDAG(
             name=editor_workflow_graph.workflow_name,
             description=editor_workflow_graph.description,
+            controls=editor_workflow_graph.controls,
             start=WorkflowStart(triggers=triggers),
             dag=workflow_dag,
         ),

--- a/admyral/models/editor.py
+++ b/admyral/models/editor.py
@@ -95,6 +95,7 @@ class EditorWorkflowGraph(BaseModel):
     workflow_id: str
     workflow_name: str
     description: str | None
+    controls: list[str] | None
     is_active: bool
     nodes: list[EditorWorkflowNode]
     edges: list[EditorWorkflowEdge]

--- a/admyral/models/workflow.py
+++ b/admyral/models/workflow.py
@@ -127,6 +127,7 @@ class WorkflowStart(BaseModel):
 class WorkflowDAG(BaseModel):
     name: str
     description: str | None = None
+    controls: list[str] | None = None
     start: WorkflowStart
     dag: dict[str, IfNode | ActionNode]
     version: str = "1"
@@ -185,5 +186,6 @@ class WorkflowMetadata(BaseModel):
     workflow_id: str
     workflow_name: str
     workflow_description: str | None = None
+    controls: list[str] | None = None
     created_at: datetime
     is_active: bool

--- a/admyral/workflow.py
+++ b/admyral/workflow.py
@@ -40,10 +40,12 @@ class Workflow:
         *,
         triggers: list[Webhook | Schedule] = [],
         description: str | None = None,
+        controls: list[str] | None = None,
     ) -> None:
         self.func = func
         self.description = description
         self.triggers = triggers
+        self.controls = controls
 
     def compile(self) -> WorkflowDAG:
         return WorkflowCompiler().compile(self)
@@ -63,11 +65,14 @@ def workflow(
     *,
     description: str | None = None,
     triggers: list[Webhook | Schedule] = [],
+    controls: list[str] | None = None,
 ) -> Workflow:
     """Decorator to create a workflow."""
 
     def inner(func: "F") -> Workflow:
-        w = Workflow(func, description=description, triggers=triggers)
+        w = Workflow(
+            func, description=description, triggers=triggers, controls=controls
+        )
         w.__doc__ = func.__doc__
         return w
 

--- a/tests/compiler/test_workflow_compiler.py
+++ b/tests/compiler/test_workflow_compiler.py
@@ -1686,6 +1686,38 @@ def test_workflow_input_with_json_body_and_default():
 #########################################################################################################
 
 
+@workflow(
+    description="This is a description of my workflow", controls=["CC4.1", "CC2.3"]
+)
+def workflow_with_controls(payload: dict[str, JsonValue]):
+    dummy_test_action1()
+
+
+def test_workflow_with_controls():
+    expected_dag = WorkflowDAG(
+        name="workflow_with_controls",
+        description="This is a description of my workflow",
+        start=WorkflowStart(triggers=[]),
+        controls=["CC4.1", "CC2.3"],
+        dag={
+            "start": ActionNode(
+                id="start", type="start", children=["dummy_test_action1"]
+            ),
+            # dummy_test_action1()
+            "dummy_test_action1": ActionNode(
+                id="dummy_test_action1",
+                type="dummy_test_action1",
+            ),
+        },
+    )
+    dag = WorkflowCompiler().compile(workflow_with_controls)
+    assert dag == expected_dag
+    assert WorkflowDAG.model_validate(dag.model_dump()) == expected_dag
+
+
+#########################################################################################################
+
+
 @workflow
 def workflow_input_mixed(payload: dict[str, JsonValue]):
     """

--- a/web/src/components/workflow-editor/workflow-settings-edit-panel.tsx
+++ b/web/src/components/workflow-editor/workflow-settings-edit-panel.tsx
@@ -8,13 +8,14 @@ import {
 	Text,
 	TextArea,
 	TextField,
+	IconButton,
 } from "@radix-ui/themes";
 import SettingsIcon from "../icons/settings-icon";
 import WorkflowEditorRightPanelBase from "./right-panel-base";
 import { useWorkflowStore } from "@/stores/workflow-store";
 import { useDeleteWorkflowApi } from "@/hooks/use-delete-workflow-api";
 import { useRouter } from "next/navigation";
-import { TrashIcon } from "@radix-ui/react-icons";
+import { TrashIcon, MinusIcon, PlusIcon } from "@radix-ui/react-icons";
 
 export default function WorkflowSettingsEditPanel() {
 	const {
@@ -23,6 +24,10 @@ export default function WorkflowSettingsEditPanel() {
 		setWorkflowName,
 		description,
 		setDescription,
+		controls,
+		addControl,
+		updateControlsByIdx,
+		deleteControlByIdx,
 	} = useWorkflowStore();
 	const deleteWorkflow = useDeleteWorkflowApi();
 	const router = useRouter();
@@ -61,6 +66,58 @@ export default function WorkflowSettingsEditPanel() {
 					/>
 				</Flex>
 
+				<Flex direction="column" gap="3">
+					<Text>Controls</Text>
+					{controls &&
+						controls.map((control, controlIdx) => (
+							<Flex
+								key={`control_${controlIdx}`}
+								direction="column"
+								gap="1"
+							>
+								<Flex direction="column" gap="1">
+									<Flex justify="between">
+										<Text size="2" color="gray">
+											Name of the Control
+										</Text>
+										<IconButton
+											radius="full"
+											color="red"
+											size="1"
+											style={{
+												cursor: "pointer",
+											}}
+											onClick={() =>
+												deleteControlByIdx(controlIdx)
+											}
+										>
+											<MinusIcon />
+										</IconButton>
+									</Flex>
+									<TextField.Root
+										variant="surface"
+										value={control}
+										onChange={(event) =>
+											updateControlsByIdx(
+												controlIdx,
+												event.target.value,
+											)
+										}
+									/>
+								</Flex>
+							</Flex>
+						))}
+					<Flex width="100%" justify="center" align="center">
+						<IconButton
+							radius="full"
+							size="1"
+							style={{ cursor: "pointer" }}
+							onClick={addControl}
+						>
+							<PlusIcon />
+						</IconButton>
+					</Flex>
+				</Flex>
 				<Box width="auto">
 					<AlertDialog.Root>
 						<AlertDialog.Trigger>

--- a/web/src/components/workflow-editor/workflow-settings-edit-panel.tsx
+++ b/web/src/components/workflow-editor/workflow-settings-edit-panel.tsx
@@ -26,7 +26,7 @@ export default function WorkflowSettingsEditPanel() {
 		setDescription,
 		controls,
 		addControl,
-		updateControlsByIdx,
+		updateControlByIdx,
 		deleteControlByIdx,
 	} = useWorkflowStore();
 	const deleteWorkflow = useDeleteWorkflowApi();
@@ -98,7 +98,7 @@ export default function WorkflowSettingsEditPanel() {
 										variant="surface"
 										value={control}
 										onChange={(event) =>
-											updateControlsByIdx(
+											updateControlByIdx(
 												controlIdx,
 												event.target.value,
 											)

--- a/web/src/components/workflows-list/workflow-list-element.tsx
+++ b/web/src/components/workflows-list/workflow-list-element.tsx
@@ -32,8 +32,12 @@ export default function WorkflowListElement({
 					)}
 					{controls !== null && controls.length > 0 && (
 						<Flex gap="2" wrap="wrap">
-							{controls.map((control) => (
-								<Badge color="blue" radius="full">
+							{controls.map((control, controlIdx) => (
+								<Badge
+									color="blue"
+									radius="full"
+									key={`${controlIdx}_${control}`}
+								>
 									{control}
 								</Badge>
 							))}

--- a/web/src/components/workflows-list/workflow-list-element.tsx
+++ b/web/src/components/workflows-list/workflow-list-element.tsx
@@ -31,7 +31,7 @@ export default function WorkflowListElement({
 						</Text>
 					)}
 					{controls !== null && controls.length > 0 && (
-						<Flex gap="2">
+						<Flex gap="2" wrap="wrap">
 							{controls.map((control) => (
 								<Badge color="blue" radius="full">
 									{control}

--- a/web/src/components/workflows-list/workflow-list-element.tsx
+++ b/web/src/components/workflows-list/workflow-list-element.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Card, Flex, IconButton, Text } from "@radix-ui/themes";
+import { Card, Flex, IconButton, Text, Badge } from "@radix-ui/themes";
 import Link from "next/link";
 import RightArrowIcon from "@/components/icons/right-arrow-icon";
 import PublishWorkflowToggleWorkflowList from "../publish-workflow-toggle/publish-workflow-toggle-workflow-list";
@@ -9,6 +9,7 @@ interface WorkflowListElementProps {
 	workflowId: string;
 	workflowName: string | null;
 	description: string | null;
+	controls: string[] | null;
 	isLive: boolean;
 }
 
@@ -16,6 +17,7 @@ export default function WorkflowListElement({
 	workflowId,
 	workflowName,
 	description,
+	controls,
 	isLive,
 }: WorkflowListElementProps) {
 	return (
@@ -27,6 +29,15 @@ export default function WorkflowListElement({
 						<Text size="2" color="gray">
 							{description}
 						</Text>
+					)}
+					{controls !== null && controls.length > 0 && (
+						<Flex gap="2">
+							{controls.map((control) => (
+								<Badge color="blue" radius="full">
+									{control}
+								</Badge>
+							))}
+						</Flex>
 					)}
 				</Flex>
 

--- a/web/src/components/workflows-list/workflows-list.tsx
+++ b/web/src/components/workflows-list/workflows-list.tsx
@@ -72,6 +72,7 @@ export default function WorkflowsList() {
 								workflowId={workflow.workflowId}
 								workflowName={workflow.workflowName}
 								description={workflow.workflowDescription}
+								controls={workflow.controls}
 								isLive={workflow.isActive}
 							/>
 						))}

--- a/web/src/stores/workflow-store.ts
+++ b/web/src/stores/workflow-store.ts
@@ -71,6 +71,7 @@ type WorkflowStoreState = TReactFlowGraph & {
 	getNodeId: () => string;
 	setWorkflowName: (workflowName: string) => void;
 	setDescription: (description: string) => void;
+	setControls: (controls: string[]) => void;
 	updateNodeData: (
 		nodeIdx: number,
 		data:
@@ -99,6 +100,7 @@ export const useWorkflowStore = create<WorkflowStoreState>((set, get) => ({
 	workflowName: "",
 	payloadCache: "",
 	description: null,
+	controls: [],
 	isActive: false,
 	nodes: [],
 	edges: [],
@@ -115,6 +117,7 @@ export const useWorkflowStore = create<WorkflowStoreState>((set, get) => ({
 			workflowName: "",
 			payloadCache: "",
 			description: null,
+			controls: [],
 			isActive: false,
 			nodes: [],
 			edges: [],
@@ -132,6 +135,7 @@ export const useWorkflowStore = create<WorkflowStoreState>((set, get) => ({
 			workflowName: "",
 			payloadCache: "",
 			description: null,
+			controls: [],
 			isActive: false,
 			nodes: [buildStartNode(windowInnerWidth)],
 			edges: [],
@@ -148,6 +152,7 @@ export const useWorkflowStore = create<WorkflowStoreState>((set, get) => ({
 				draft.workflowId = workflow.workflowId;
 				draft.workflowName = workflow.workflowName;
 				draft.description = workflow.description;
+				draft.controls = workflow.controls;
 				draft.isActive = workflow.isActive;
 				draft.nodes = workflow.nodes;
 				draft.edges = workflow.edges;
@@ -181,6 +186,7 @@ export const useWorkflowStore = create<WorkflowStoreState>((set, get) => ({
 			workflowId: get().workflowId,
 			workflowName: get().workflowName,
 			description: get().description,
+			controls: get().controls,
 			isActive: get().isActive,
 			nodes: get().nodes.map((node) => node.data),
 			edges: get().edges.map((edge) => ({
@@ -294,6 +300,12 @@ export const useWorkflowStore = create<WorkflowStoreState>((set, get) => ({
 		set(
 			produce((draft) => {
 				draft.description = description;
+			}),
+		),
+	setControls: (controls) =>
+		set(
+			produce((draft) => {
+				draft.controls = controls;
 			}),
 		),
 	updateNodeData: (

--- a/web/src/stores/workflow-store.ts
+++ b/web/src/stores/workflow-store.ts
@@ -283,6 +283,9 @@ export const useWorkflowStore = create<WorkflowStoreState>((set, get) => ({
 	addControl: () =>
 		set(
 			produce((draft) => {
+				if (draft.controls === null) {
+					draft.controls = [];
+				}
 				draft.controls.push("");
 			}),
 		),

--- a/web/src/stores/workflow-store.ts
+++ b/web/src/stores/workflow-store.ts
@@ -83,7 +83,7 @@ type WorkflowStoreState = TReactFlowGraph & {
 		webhookId: string,
 		webhookSecret: string,
 	) => void;
-	updateControlsByIdx: (controlIdx: number, control: string) => void;
+	updateControlByIdx: (controlIdx: number, control: string) => void;
 	deleteNodeByIdx: (nodeIdx: number) => void;
 	deleteControlByIdx: (controlIdx: number) => void;
 	duplicateNodeByIdx: (nodeIdx: number) => void;
@@ -350,7 +350,7 @@ export const useWorkflowStore = create<WorkflowStoreState>((set, get) => ({
 				}
 			}),
 		),
-	updateControlsByIdx: (controlIdx: number, control: string) =>
+	updateControlByIdx: (controlIdx: number, control: string) =>
 		set(
 			produce((draft) => {
 				draft.controls[controlIdx] = control;

--- a/web/src/stores/workflow-store.ts
+++ b/web/src/stores/workflow-store.ts
@@ -68,10 +68,10 @@ type WorkflowStoreState = TReactFlowGraph & {
 	onNodesChange: OnNodesChange;
 	onEdgesChange: OnEdgesChange;
 	addNode: (node: TReactFlowNode) => void;
+	addControl: () => void;
 	getNodeId: () => string;
 	setWorkflowName: (workflowName: string) => void;
 	setDescription: (description: string) => void;
-	setControls: (controls: string[]) => void;
 	updateNodeData: (
 		nodeIdx: number,
 		data:
@@ -83,7 +83,9 @@ type WorkflowStoreState = TReactFlowGraph & {
 		webhookId: string,
 		webhookSecret: string,
 	) => void;
+	updateControlsByIdx: (controlIdx: number, control: string) => void;
 	deleteNodeByIdx: (nodeIdx: number) => void;
+	deleteControlByIdx: (controlIdx: number) => void;
 	duplicateNodeByIdx: (nodeIdx: number) => void;
 	// Settings Side Panel
 	detailPageType: "workflow" | "action" | null;
@@ -278,6 +280,12 @@ export const useWorkflowStore = create<WorkflowStoreState>((set, get) => ({
 				draft.nodes.push(node);
 			}),
 		),
+	addControl: () =>
+		set(
+			produce((draft) => {
+				draft.controls.push("");
+			}),
+		),
 	getNodeId: () => {
 		let newIdx = get().nextId;
 		let nodeId = `node_${newIdx}`;
@@ -300,12 +308,6 @@ export const useWorkflowStore = create<WorkflowStoreState>((set, get) => ({
 		set(
 			produce((draft) => {
 				draft.description = description;
-			}),
-		),
-	setControls: (controls) =>
-		set(
-			produce((draft) => {
-				draft.controls = controls;
 			}),
 		),
 	updateNodeData: (
@@ -345,6 +347,12 @@ export const useWorkflowStore = create<WorkflowStoreState>((set, get) => ({
 				}
 			}),
 		),
+	updateControlsByIdx: (controlIdx: number, control: string) =>
+		set(
+			produce((draft) => {
+				draft.controls[controlIdx] = control;
+			}),
+		),
 	duplicateNodeByIdx: (nodeIdx: number) => {
 		const newNodeId = get().getNodeId();
 		set(
@@ -378,6 +386,12 @@ export const useWorkflowStore = create<WorkflowStoreState>((set, get) => ({
 					draft.detailPageType = null;
 					draft.selectedNodeIdx = null;
 				}
+			}),
+		),
+	deleteControlByIdx: (controlIdx: number) =>
+		set(
+			produce((draft) => {
+				draft.controls.splice(controlIdx, 1);
 			}),
 		),
 	// Settings Side Panel

--- a/web/src/types/react-flow.ts
+++ b/web/src/types/react-flow.ts
@@ -96,6 +96,7 @@ export const EditorWorkflowGraph = withCamelCaseTransform(
 		workflow_id: z.string(),
 		workflow_name: z.string(),
 		description: z.string().nullable(),
+		controls: z.array(z.string()).nullable(),
 		is_active: z.boolean(),
 		nodes: z.array(
 			z.union([

--- a/web/src/types/react-flow.ts
+++ b/web/src/types/react-flow.ts
@@ -117,6 +117,7 @@ export type TReactFlowGraph = {
 	workflowId: string;
 	workflowName: string;
 	description: string | null;
+	controls: string[] | null;
 	isActive: boolean;
 	nodes: TReactFlowNode[];
 	edges: TReactFlowEdge[];
@@ -183,6 +184,7 @@ export const EditorWorkflowGraphSnakeCase = withSnakeCaseTransform(
 		workflowId: z.string(),
 		workflowName: z.string(),
 		description: z.string().nullable(),
+		controls: z.array(z.string()).nullable(),
 		isActive: z.boolean(),
 		nodes: z.array(
 			z.union([

--- a/web/src/types/workflows.ts
+++ b/web/src/types/workflows.ts
@@ -5,6 +5,7 @@ const WorkflowMetadataBase = z.object({
 	workflow_id: z.string(),
 	workflow_name: z.string().nullable(),
 	workflow_description: z.string().nullable(),
+	controls: z.array(z.string()).nullable(),
 	created_at: z.string(),
 	is_active: z.boolean(),
 });


### PR DESCRIPTION
This PR adds the option to add control mapping to workflows. 
This can either be done via the @workflow decorator or the Web UI.