### PR TITLE
Display Status of latest run in Editor

### DIFF
--- a/admyral/server/endpoints/workflow_run_endpoints.py
+++ b/admyral/server/endpoints/workflow_run_endpoints.py
@@ -15,7 +15,9 @@ router = APIRouter()
 
 @router.get("/{workflow_id}", status_code=status.HTTP_200_OK)
 async def list_workflow_runs(
-    workflow_id: str, authenticated_user: AuthenticatedUser = Depends(authenticate)
+    workflow_id: str,
+    limit: int | None = 100,
+    authenticated_user: AuthenticatedUser = Depends(authenticate),
 ) -> list[WorkflowRunMetadata]:
     """
     List all workflow runs.
@@ -27,7 +29,7 @@ async def list_workflow_runs(
         A list of workflow runs.
     """
     return await get_admyral_store().list_workflow_runs(
-        authenticated_user.user_id, workflow_id
+        authenticated_user.user_id, workflow_id, limit=limit
     )
 
 

--- a/web/src/components/workflow-editor/run-history/latest-workflow-run-status.tsx
+++ b/web/src/components/workflow-editor/run-history/latest-workflow-run-status.tsx
@@ -15,16 +15,12 @@ export function WorkflowRunStatus({ workflowId }: { workflowId: string }) {
 		}
 	}, [data]);
 
-	if (isPending) {
-		return <Text size="2">Loading latest run...</Text>;
+	if (isPending || !latestRun) {
+		return;
 	}
 
 	if (error) {
 		return <ErrorCallout />;
-	}
-
-	if (!latestRun) {
-		return;
 	}
 
 	return (

--- a/web/src/components/workflow-editor/run-history/latest-workflow-run-status.tsx
+++ b/web/src/components/workflow-editor/run-history/latest-workflow-run-status.tsx
@@ -1,8 +1,7 @@
 import { useListWorkflowRunsApi } from "@/hooks/use-list-workflow-runs-api";
-import { Flex, Text } from "@radix-ui/themes";
+import { Flex } from "@radix-ui/themes";
 import { useEffect, useState } from "react";
 import type { TWorkflowRunMetadata } from "@/types/workflow-runs";
-import ErrorCallout from "@/components/utils/error-callout";
 import WorkflowRunStatusIndicator from "./workflow-run-status-indicator";
 
 export function WorkflowRunStatus({ workflowId }: { workflowId: string }) {
@@ -15,12 +14,8 @@ export function WorkflowRunStatus({ workflowId }: { workflowId: string }) {
 		}
 	}, [data]);
 
-	if (isPending || !latestRun) {
-		return;
-	}
-
-	if (error) {
-		return <ErrorCallout />;
+	if (error || isPending || !latestRun) {
+		return null;
 	}
 
 	return (

--- a/web/src/components/workflow-editor/run-history/latest-workflow-run-status.tsx
+++ b/web/src/components/workflow-editor/run-history/latest-workflow-run-status.tsx
@@ -10,7 +10,7 @@ export function WorkflowRunStatus({ workflowId }: { workflowId: string }) {
 	const [latestRun, setLatestRun] = useState<TWorkflowRunMetadata>();
 
 	useEffect(() => {
-		if (data) {
+		if (data && data.length > 0) {
 			setLatestRun(data[0]);
 		}
 	}, [data]);

--- a/web/src/components/workflow-editor/run-history/latest-workflow-run-status.tsx
+++ b/web/src/components/workflow-editor/run-history/latest-workflow-run-status.tsx
@@ -1,0 +1,35 @@
+import { useListWorkflowRunsApi } from "@/hooks/use-list-workflow-runs-api";
+import { Flex, Text } from "@radix-ui/themes";
+import { useEffect, useState } from "react";
+import type { TWorkflowRunMetadata } from "@/types/workflow-runs";
+import ErrorCallout from "@/components/utils/error-callout";
+import WorkflowRunStatusIndicator from "./workflow-run-status-indicator";
+
+export function WorkflowRunStatus({ workflowId }: { workflowId: string }) {
+	const { data, isPending, error } = useListWorkflowRunsApi(workflowId, 1);
+	const [latestRun, setLatestRun] = useState<TWorkflowRunMetadata>();
+
+	useEffect(() => {
+		if (data) {
+			setLatestRun(data[0]);
+		}
+	}, [data]);
+
+	if (isPending) {
+		return <Text size="2">Loading latest run...</Text>;
+	}
+
+	if (error) {
+		return <ErrorCallout />;
+	}
+
+	if (!latestRun) {
+		return;
+	}
+
+	return (
+		<Flex align="center" gap="2" height="25px">
+			<WorkflowRunStatusIndicator workflowRun={latestRun} />
+		</Flex>
+	);
+}

--- a/web/src/components/workflow-editor/run-history/workflow-run-history.tsx
+++ b/web/src/components/workflow-editor/run-history/workflow-run-history.tsx
@@ -1,43 +1,26 @@
 import { useListWorkflowRunsApi } from "@/hooks/use-list-workflow-runs-api";
 import { useToast } from "@/providers/toast";
-import { Box, Flex, Spinner, ScrollArea, Text } from "@radix-ui/themes";
+import { Box, Flex, ScrollArea, Text } from "@radix-ui/themes";
 import { useEffect, useState } from "react";
 import WorkflowRunTrace from "./workflow-run-trace";
 import Row from "./row";
 import ErrorCallout from "@/components/utils/error-callout";
-import { CheckCircledIcon, CrossCircledIcon } from "@radix-ui/react-icons";
 import { TWorkflowRunMetadata } from "@/types/workflow-runs";
+import WorkflowRunStatusIndicator from "./workflow-run-status-indicator";
 
 function WorkflowRunRow({
-	workflowRun: { createdAt, failedAt, completedAt },
+	workflowRun,
 }: {
 	workflowRun: TWorkflowRunMetadata;
 }) {
-	if (failedAt === null && completedAt === null) {
-		// In Progress
-		return (
-			<Flex align="center" justify="between" width="100%">
-				<Text size="1">{createdAt}</Text>
-				<Spinner size="1" />
-			</Flex>
-		);
-	}
+	const createdAtAsReadableString = new Date(
+		workflowRun.createdAt,
+	).toLocaleString("en-US");
 
-	if (completedAt === null) {
-		// Failure
-		return (
-			<Flex align="center" justify="between" width="100%">
-				<Text size="1">{createdAt}</Text>
-				<CrossCircledIcon color="red" />
-			</Flex>
-		);
-	}
-
-	// Success
 	return (
 		<Flex align="center" justify="between" width="100%">
-			<Text size="1">{createdAt}</Text>
-			<CheckCircledIcon color="green" />
+			<Text size="1">{createdAtAsReadableString}</Text>
+			<WorkflowRunStatusIndicator workflowRun={workflowRun} />
 		</Flex>
 	);
 }

--- a/web/src/components/workflow-editor/run-history/workflow-run-status-indicator.tsx
+++ b/web/src/components/workflow-editor/run-history/workflow-run-status-indicator.tsx
@@ -1,0 +1,34 @@
+import { Spinner, Flex } from "@radix-ui/themes";
+import { CheckCircledIcon, CrossCircledIcon } from "@radix-ui/react-icons";
+import type { TWorkflowRunMetadata } from "@/types/workflow-runs";
+
+export default function WorkflowRunStatusIndicator({
+	workflowRun: { failedAt, completedAt },
+}: {
+	workflowRun: TWorkflowRunMetadata;
+}) {
+	if (failedAt === null && completedAt === null) {
+		// In Progress
+		return (
+			<Flex align="center" gap="2">
+				<Spinner size="1" />
+			</Flex>
+		);
+	}
+
+	if (completedAt === null) {
+		// Failure
+		return (
+			<Flex align="center" gap="2">
+				<CrossCircledIcon color="red" />
+			</Flex>
+		);
+	}
+
+	// Success
+	return (
+		<Flex align="center" gap="2">
+			<CheckCircledIcon color="green" />
+		</Flex>
+	);
+}

--- a/web/src/components/workflow-editor/run-history/workflow-run-status-indicator.tsx
+++ b/web/src/components/workflow-editor/run-history/workflow-run-status-indicator.tsx
@@ -11,7 +11,7 @@ export default function WorkflowRunStatusIndicator({
 		// In Progress
 		return (
 			<Flex align="center" gap="2">
-				<Spinner size="1" />
+				<Spinner size="1" aria-label="Workflow run in progress" />
 			</Flex>
 		);
 	}
@@ -20,7 +20,10 @@ export default function WorkflowRunStatusIndicator({
 		// Failure
 		return (
 			<Flex align="center" gap="2">
-				<CrossCircledIcon color="red" />
+				<CrossCircledIcon
+					color="red"
+					aria-label="Workflow run failed"
+				/>
 			</Flex>
 		);
 	}
@@ -28,7 +31,10 @@ export default function WorkflowRunStatusIndicator({
 	// Success
 	return (
 		<Flex align="center" gap="2">
-			<CheckCircledIcon color="green" />
+			<CheckCircledIcon
+				color="green"
+				aria-label="Workflow run succeeded"
+			/>
 		</Flex>
 	);
 }

--- a/web/src/components/workflow-editor/run-history/workflow-run-trace.tsx
+++ b/web/src/components/workflow-editor/run-history/workflow-run-trace.tsx
@@ -78,12 +78,18 @@ export default function WorkflowRunTrace({
 							selected={idx === selectedStepIdx}
 							onClickOnUnselectedRow={() => handleClickStep(idx)}
 						>
-							<Flex align="center" justify="between" width="100%">
-								<ActionIcon
-									actionType={workflowStep.actionType}
-								/>
+							<Flex align="center" width="100%" gap="2">
+								<Flex
+									width="24px"
+									height="24px"
+									justify="center"
+								>
+									<ActionIcon
+										actionType={workflowStep.actionType}
+									/>
+								</Flex>
 								<Flex align="center" justify="center" gap="1">
-									<Text size="1">
+									<Text size="1" align="left">
 										{workflowStep.actionType === "start"
 											? "Start"
 											: actionsIndex[

--- a/web/src/components/workflow-editor/workflow-editor.tsx
+++ b/web/src/components/workflow-editor/workflow-editor.tsx
@@ -184,7 +184,7 @@ export default function WorkflowEditor({
 							</Text>
 						</Flex>
 
-						<Flex justify="center" align="center" gap="4">
+						<Flex justify="center" align="center">
 							<Tabs.Root
 								value={view}
 								onValueChange={(page) => setView(page as View)}

--- a/web/src/components/workflow-editor/workflow-editor.tsx
+++ b/web/src/components/workflow-editor/workflow-editor.tsx
@@ -24,6 +24,7 @@ import { AxiosError } from "axios";
 import { useRouter } from "next/navigation";
 import { SaveWorkflowProvider } from "@/providers/save-workflow";
 import NewWorkflowModal from "./new-workflow-modal";
+import { WorkflowRunStatus } from "./run-history/latest-workflow-run-status";
 
 type View = "workflowBuilder" | "runHistory";
 
@@ -162,7 +163,7 @@ export default function WorkflowEditor({
 						pt="2"
 						pl="4"
 						pr="4"
-						columns="1fr 200px 1fr"
+						columns="1fr auto 1fr"
 						className="border-b-2 border-gray-200"
 						align="center"
 						height="56px"
@@ -183,25 +184,30 @@ export default function WorkflowEditor({
 							</Text>
 						</Flex>
 
-						<Flex justify="center" align="center">
+						<Flex justify="center" align="center" gap="4">
 							<Tabs.Root
 								value={view}
 								onValueChange={(page) => setView(page as View)}
 							>
-								<Tabs.List size="1">
-									<Tabs.Trigger
-										value="workflowBuilder"
-										style={{ cursor: "pointer" }}
-									>
-										Workflow Builder
-									</Tabs.Trigger>
-									<Tabs.Trigger
-										value="runHistory"
-										style={{ cursor: "pointer" }}
-									>
-										Run History
-									</Tabs.Trigger>
-								</Tabs.List>
+								<Flex align="center">
+									<Tabs.List size="1">
+										<Tabs.Trigger
+											value="workflowBuilder"
+											style={{ cursor: "pointer" }}
+										>
+											Workflow Builder
+										</Tabs.Trigger>
+										<Tabs.Trigger
+											value="runHistory"
+											style={{ cursor: "pointer" }}
+										>
+											Run History
+										</Tabs.Trigger>
+									</Tabs.List>
+									<WorkflowRunStatus
+										workflowId={workflowId}
+									/>
+								</Flex>
 							</Tabs.Root>
 						</Flex>
 

--- a/web/src/hooks/use-list-workflow-runs-api.ts
+++ b/web/src/hooks/use-list-workflow-runs-api.ts
@@ -25,7 +25,7 @@ const REFETCH_INTERVAL_1_SECOND = 1_000; // in ms
 
 export const useListWorkflowRunsApi = (workflowId: string, limit?: number) => {
 	return useQuery({
-		queryKey: ["workflowRuns", workflowId],
+		queryKey: ["workflowRuns", workflowId, limit],
 		queryFn: () => buildListWorkflowRunsApi(workflowId, limit)(),
 		refetchInterval: REFETCH_INTERVAL_1_SECOND,
 	});

--- a/web/src/hooks/use-list-workflow-runs-api.ts
+++ b/web/src/hooks/use-list-workflow-runs-api.ts
@@ -7,7 +7,9 @@ import { WorkflowRunMetadata } from "@/types/workflow-runs";
 import { HTTPMethod } from "@/types/api";
 
 // GET /api/v1/runs/<workflow-id>
-const ListWorkflowRunsRequest = z.void();
+const ListWorkflowRunsRequest = z.object({
+	limit: z.number().optional(),
+});
 const ListWorkflowRunsResponse = z.array(WorkflowRunMetadata);
 
 const buildListWorkflowRunsApi = (workflowId: string, limit?: number) =>
@@ -16,7 +18,7 @@ const buildListWorkflowRunsApi = (workflowId: string, limit?: number) =>
 		z.infer<typeof ListWorkflowRunsResponse>
 	>({
 		method: HTTPMethod.GET,
-		path: `/api/v1/runs/${workflowId}${limit ? `?limit=${limit}` : ""}`,
+		path: `/api/v1/runs/${workflowId}`,
 		requestSchema: ListWorkflowRunsRequest,
 		responseSchema: ListWorkflowRunsResponse,
 	});
@@ -26,7 +28,7 @@ const REFETCH_INTERVAL_1_SECOND = 1_000; // in ms
 export const useListWorkflowRunsApi = (workflowId: string, limit?: number) => {
 	return useQuery({
 		queryKey: ["workflowRuns", workflowId, limit],
-		queryFn: () => buildListWorkflowRunsApi(workflowId, limit)(),
+		queryFn: () => buildListWorkflowRunsApi(workflowId, limit)({}),
 		refetchInterval: REFETCH_INTERVAL_1_SECOND,
 	});
 };

--- a/web/src/hooks/use-list-workflow-runs-api.ts
+++ b/web/src/hooks/use-list-workflow-runs-api.ts
@@ -12,7 +12,7 @@ const ListWorkflowRunsRequest = z.object({
 });
 const ListWorkflowRunsResponse = z.array(WorkflowRunMetadata);
 
-const buildListWorkflowRunsApi = (workflowId: string, limit?: number) =>
+const buildListWorkflowRunsApi = (workflowId: string) =>
 	api<
 		z.infer<typeof ListWorkflowRunsRequest>,
 		z.infer<typeof ListWorkflowRunsResponse>
@@ -28,7 +28,7 @@ const REFETCH_INTERVAL_1_SECOND = 1_000; // in ms
 export const useListWorkflowRunsApi = (workflowId: string, limit?: number) => {
 	return useQuery({
 		queryKey: ["workflowRuns", workflowId, limit],
-		queryFn: () => buildListWorkflowRunsApi(workflowId, limit)({}),
+		queryFn: () => buildListWorkflowRunsApi(workflowId)({ limit }),
 		refetchInterval: REFETCH_INTERVAL_1_SECOND,
 	});
 };

--- a/web/src/hooks/use-list-workflow-runs-api.ts
+++ b/web/src/hooks/use-list-workflow-runs-api.ts
@@ -10,23 +10,23 @@ import { HTTPMethod } from "@/types/api";
 const ListWorkflowRunsRequest = z.void();
 const ListWorkflowRunsResponse = z.array(WorkflowRunMetadata);
 
-const buildListWorkflowRunsApi = (workflowId: string) =>
+const buildListWorkflowRunsApi = (workflowId: string, limit?: number) =>
 	api<
 		z.infer<typeof ListWorkflowRunsRequest>,
 		z.infer<typeof ListWorkflowRunsResponse>
 	>({
 		method: HTTPMethod.GET,
-		path: `/api/v1/runs/${workflowId}`,
+		path: `/api/v1/runs/${workflowId}${limit ? `?limit=${limit}` : ""}`,
 		requestSchema: ListWorkflowRunsRequest,
 		responseSchema: ListWorkflowRunsResponse,
 	});
 
 const REFETCH_INTERVAL_1_SECOND = 1_000; // in ms
 
-export const useListWorkflowRunsApi = (workflowId: string) => {
+export const useListWorkflowRunsApi = (workflowId: string, limit?: number) => {
 	return useQuery({
 		queryKey: ["workflowRuns", workflowId],
-		queryFn: () => buildListWorkflowRunsApi(workflowId)(),
+		queryFn: () => buildListWorkflowRunsApi(workflowId, limit)(),
 		refetchInterval: REFETCH_INTERVAL_1_SECOND,
 	});
 };


### PR DESCRIPTION
This PR changes the following:
- adjusts the api endpoint to retreive information about workflow run with optional limit parameter
- display latest run (error/success) in editor next to Run History Tab
- creates two new components for the general state of the workflow run and the to display the latest run within the editor
- left-alignes the Steps in the Workflow History

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced a `limit` parameter for the `list_workflow_runs` endpoint, allowing users to specify the maximum number of workflow runs returned.
  - Added a new `WorkflowRunStatus` component to display the status of the latest workflow run.
  - Implemented a `WorkflowRunStatusIndicator` component for visual representation of workflow run statuses.

- **Improvements**
  - Streamlined the `WorkflowRunRow` component to simplify status display logic.
  - Enhanced the layout of the `WorkflowEditor` for better organization and real-time status updates.
  - Refined the rendering of workflow steps in the `WorkflowRunTrace` component for improved visual consistency.

- **Bug Fixes**
  - Maintained existing error handling and loading states across components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->